### PR TITLE
bump to 1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.3'
           - '1.9'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "AdjustCRC"
 uuid = "ff5396d8-130b-441a-8382-fec03de644a8"
 authors = ["Steven G. Johnson <stevenj@alum.mit.edu> and contributors"]
-version = "1.0.0-DEV"
+version = "1.0.0"
 
 [deps]
 CRC32 = "b4567568-9dcc-467e-9b62-c342d3a501d3"
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
 
 [compat]
-julia = "1"
+julia = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/AdjustCRC.jl
+++ b/src/AdjustCRC.jl
@@ -105,7 +105,8 @@ position within an array.
 function adjust_crc(crc::F, io::IO, wantcrc::UInt32) where {F}
     le(v::UInt32) = [v%UInt8, (v>>8)%UInt8, (v>>16)%UInt8, (v>>24)%UInt8]
 
-    isreadable(io) && iswritable(io) && throw(ArgumentError("stream must be readable and writable"))
+    isreadable(io) || throw(ArgumentError("stream must be readable"))
+    iswritable(io) || throw(ArgumentError("stream must be writable"))
 
     # specialized version of adjust_crc32c! for writing to end
     write(io, htol(bwcrc(le(crc(seekstart(io)) ⊻ 0xffffffff), wantcrc, revtable(crc))))

--- a/src/AdjustCRC.jl
+++ b/src/AdjustCRC.jl
@@ -77,7 +77,7 @@ function adjust_crc!(crc::F, a::AbstractVector{UInt8}, wantcrc::UInt32, fixpos::
 
     # Algorithm 8 from Stigge et al.
     checkbounds(a, fixpos:fixpos+3)
-    @views store_le!(a, fixpos, crc(a[begin:fixpos-1]) ⊻ 0xffffffff)
+    @views store_le!(a, fixpos, crc(a[firstindex(a):fixpos-1]) ⊻ 0xffffffff)
     @views store_le!(a, fixpos, bwcrc(a[fixpos:end], wantcrc, revtable(crc)))
     return a
 end


### PR DESCRIPTION
note that CRC32.jl requires Julia 1.3, so we should follow suit.  also a bugfix.